### PR TITLE
Build with Text v2 & HUnit v1.6

### DIFF
--- a/hexpat.cabal
+++ b/hexpat.cabal
@@ -142,7 +142,7 @@ Library
     base >= 3 && < 5,
     bytestring,
     transformers,
-    text >= 0.5.0.0 && < 1.3.0.0,
+    text >= 0.5.0.0 && < 2.1.0.0,
     utf8-string >= 0.3 && < 1.1,
     deepseq >= 1.1.0.0 && < 1.5.0.0,
     containers,

--- a/test/hexpat-tests.cabal
+++ b/test/hexpat-tests.cabal
@@ -8,7 +8,7 @@ Executable testsuite
   main-is:         TestSuite.hs
 
   build-depends:
-    HUnit < 1.3,
+    HUnit < 1.7,
     QuickCheck >= 2.7.0.0,
     base >= 3 && < 5,
     bytestring,


### PR DESCRIPTION
Builds successfully with `cabal build --enable-tests --enable-documentation --constraint 'text>=2'`.

Tests complete successfully with: `cd test; cabal run`