### PR TITLE
Bump Dependency Bounds & Fix Test Suite

### DIFF
--- a/hexpat.cabal
+++ b/hexpat.cabal
@@ -142,7 +142,7 @@ Library
     base >= 3 && < 5,
     bytestring,
     transformers,
-    text >= 0.5.0.0 && < 1.3.0.0,
+    text >= 0.5.0.0 && < 2.1.0.0,
     utf8-string >= 0.3 && < 1.1,
     deepseq >= 1.1.0.0 && < 1.5.0.0,
     containers,

--- a/hexpat.cabal
+++ b/hexpat.cabal
@@ -144,7 +144,7 @@ Library
     transformers,
     text >= 0.5.0.0 && < 2.1.0.0,
     utf8-string >= 0.3 && < 1.1,
-    deepseq >= 1.1.0.0 && < 1.5.0.0,
+    deepseq >= 1.1.0.0 && < 1.6.0.0,
     containers,
     List >= 0.4.2 && < 0.7
   Exposed-Modules:

--- a/hexpat.cabal
+++ b/hexpat.cabal
@@ -144,7 +144,7 @@ Library
     transformers,
     text >= 0.5.0.0 && < 2.1.0.0,
     utf8-string >= 0.3 && < 1.1,
-    deepseq >= 1.1.0.0 && < 1.6.0.0,
+    deepseq >= 1.1.0.0 && < 1.7.0.0,
     containers,
     List >= 0.4.2 && < 0.7
   Exposed-Modules:

--- a/test/cabal.project
+++ b/test/cabal.project
@@ -1,0 +1,1 @@
+packages: ../hexpat.cabal ./hexpat-tests.cabal

--- a/test/hexpat-tests.cabal
+++ b/test/hexpat-tests.cabal
@@ -8,7 +8,7 @@ Executable testsuite
   main-is:         TestSuite.hs
 
   build-depends:
-    HUnit < 1.3,
+    HUnit < 1.7,
     QuickCheck >= 2.7.0.0,
     base >= 3 && < 5,
     bytestring,

--- a/test/suite/Text/XML/Expat/ParallelTest.hs
+++ b/test/suite/Text/XML/Expat/ParallelTest.hs
@@ -10,6 +10,7 @@ import Text.XML.Expat.ParseFormat (normalizeText)
 import Text.XML.Expat.Tree
 import Text.XML.Expat.Format
 
+import Control.Monad
 import Control.Concurrent
 import Control.Exception
 import Control.Monad.State.Strict


### PR DESCRIPTION
Extension of https://github.com/the-real-blackh/hexpat/pull/13

Bump deepseq to support 1.5.0.0, fix compilation error in test suite.

Tested builds with `stack build --resolver nightly-2024-02-04` & `cabal build -w ghc-9.8 --constraint='deepseq==1.5.0.0`

Test-suite passed with `stack run --resolver ngihtly-2024-02-04` & `cabal run -w ghc-9.8 --constraint='deepseq==1.5.0.0'` in `test/` directory.